### PR TITLE
Fixed jcon_tcp and jcon_unix.

### DIFF
--- a/inc/jayc/jcon_client_tcp.h
+++ b/inc/jayc/jcon_client_tcp.h
@@ -15,7 +15,7 @@
 #define INCLUDE_JCON_CLIENT_TCP_H
 
 #include <jayc/jcon_client.h>
-#include <jayc/jcon_tcp.h>
+#include <jayc/jcon_socketTCP.h>
 #include <jayc/jlog.h>
 
 #ifdef __cplusplus
@@ -49,7 +49,7 @@ jcon_client_t *jcon_client_tcp_session_init(char *address, uint16_t port, jlog_t
  * @return            jcon_client session for new connection.
  * @return            @c NULL , if error occured.
  */
-jcon_client_t *jcon_client_tcp_session_tcpClone(jcon_tcp_t *tcp_session, jlog_t *logger);
+jcon_client_t *jcon_client_tcp_session_tcpClone(jcon_socket_t *tcp_session, jlog_t *logger);
 
 #ifdef __cplusplus
 }

--- a/inc/jayc/jcon_client_unix.h
+++ b/inc/jayc/jcon_client_unix.h
@@ -15,7 +15,7 @@
 #define INCLUDE_JCON_CLIENT_UNIX_H
 
 #include <jayc/jcon_client.h>
-#include <jayc/jcon_unix.h>
+#include <jayc/jcon_socketUnix.h>
 #include <jayc/jlog.h>
 
 #ifdef __cplusplus
@@ -48,7 +48,7 @@ jcon_client_t *jcon_client_unix_session_init(char *filepath, jlog_t *logger);
  * @return              jcon_client session for new connection.
  * @return              @c NULL , if error occured.
  */
-jcon_client_t *jcon_client_unix_session_unixClone(jcon_unix_t *unix_session, jlog_t *logger);
+jcon_client_t *jcon_client_unix_session_unixClone(jcon_socket_t *unix_session, jlog_t *logger);
 
 #ifdef __cplusplus
 }

--- a/inc/jayc/jcon_socket.h
+++ b/inc/jayc/jcon_socket.h
@@ -1,0 +1,209 @@
+/**
+ * @file jcon_socket.h
+ * @author Manuel Nadji (https://github.com/gnarrf95)
+ * 
+ * @brief General functions for socket operation.
+ * 
+ * @date 2020-10-05
+ * @copyright Copyright (c) 2020 by Manuel Nadji
+ * 
+ */
+
+#ifndef INCLUDE_JCON_SOCKET_H
+#define INCLUDE_JCON_SOCKET_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Session object.
+ * 
+ * Holds data for socket operation.
+ */
+typedef struct __jcon_socket_session jcon_socket_t;
+
+/**
+ * @brief Frees session memory.
+ * 
+ * @param session Session object to free.
+ */
+void jcon_socket_free(jcon_socket_t *session);
+
+/**
+ * @brief Connect to server.
+ * 
+ * Creates socket and connects to a server.
+ * This will mark the session as a client,
+ * so no server functions ( @c #jcon_socket_accept() )
+ * can be called using this session.
+ * 
+ * @param session Session to connect.
+ * 
+ * @return        @c true , if connection was established.
+ * @return        @c false , if connection failed.
+ */
+int jcon_socket_connect(jcon_socket_t *session);
+
+/**
+ * @brief Binds socket to address.
+ * 
+ * This will mark the session as a server,
+ * therefore no client functions
+ * ( @c #jcon_socket_recvData() and @c #jcon_socket_sendData() )
+ * can be called using this session.
+ * 
+ * @param session Session to bind.
+ * 
+ * @return        @c true , if socket was bound to address.
+ * @return        @c false , if binding failed.
+ */
+int jcon_socket_bind(jcon_socket_t *session);
+
+/**
+ * @brief Closes socket.
+ * 
+ * This will close the socket and
+ * unmark the session.
+ * Afterwards it can be created as a client
+ * or server again.
+ * 
+ * @param session Session to close.
+ */
+void jcon_socket_close(jcon_socket_t *session);
+
+/**
+ * @brief Checks wether input is available on socket.
+ * 
+ * Checks for input using @c poll() .
+ * 
+ * <b>For clients:</b>
+ * @c true as return says, that data is available
+ * to read.
+ * 
+ * <b>For servers:</b>
+ * @c true means, that a new client is requesting
+ * a connection.
+ * 
+ * Also detects disconnects and automatically
+ * closes the session.
+ * 
+ * @param session Session to check.
+ * @param timeout Timeout for @c poll() . Stops blocking,
+ *                if no new input was detected in time.
+ * 
+ * @return        @c true , if new input is available.
+ * @return        @c false , if @c poll() timed out,
+ *                or error occured.
+ */
+int jcon_socket_pollForInput(jcon_socket_t *session, int timeout);
+
+/**
+ * @brief Accepts connection request.
+ * 
+ * <b>Server function</b>
+ * 
+ * If new connection is available, accepts the connection
+ * and returns client connection as new session.
+ * 
+ * @param session Server session, to accept connection.
+ * 
+ * @return        Session object of client connection.
+ * @return        @c NULL , if no new connection was
+ *                available or error occured.
+ */
+jcon_socket_t *jcon_socket_accept(jcon_socket_t *session);
+
+/**
+ * @brief Recieve data from socket.
+ * 
+ * <b>Client function</b>
+ * 
+ * If new data is available (check using @c #jcon_tcp_pollForInput() ),
+ * data can be read using this function.
+ * 
+ * Data is read from socket using buffer, and if data_ptr is not
+ * @c NULL , is copied in data_ptr.
+ * If size of data read exceeds the buffer size (data_size), it is
+ * trimmed to fit in data_ptr. This is done to prevent buffer
+ * overflow.
+ * 
+ * If data_ptr is @c NULL , the data is still read, but it is
+ * discarded afterwards.
+ * This can be used o skip offsets in binary data.
+ * 
+ * If EOF is recieved, the session is automatically closed.
+ * 
+ * @param session   Session to read from.
+ * @param data_ptr  Buffer to hold data.
+ * @param data_size Buffer size.
+ * 
+ * @return          Size of data read.
+ * @return          @c 0 , if no data read or error occured.
+ */
+size_t jcon_socket_recvData(jcon_socket_t *session, void *data_ptr, size_t data_size);
+
+/**
+ * @brief Send data via socket.
+ * 
+ * <b>Client function</b>
+ * 
+ * If socket is connected, data can be sent using this function.
+ * The data in data_ptr is written, but only so many bytes as data_size
+ * states.
+ * 
+ * This function detects a disconnect and automatically closes
+ * the session.
+ * 
+ * @param session   Session to send to.
+ * @param data_ptr  Buffer with data to read.
+ * @param data_size Buffer size.
+ * 
+ * @return          Size of data sent.
+ * @return          @c 0 , if no data sent or error occured.
+ */
+size_t jcon_socket_sendData(jcon_socket_t *session, void *data_ptr, size_t data_size);
+
+/**
+ * @brief Checks if the session is connected.
+ * 
+ * @param session Session to check.
+ * 
+ * @return        @c true , if session connected.
+ * @return        @c false , if session closed or error occured.
+ */
+int jcon_socket_isConnected(jcon_socket_t *session);
+
+/**
+ * @brief Returns what type of socket the session is holding.
+ * 
+ * <b>Example:</b> "TCP", "UNIX"
+ * 
+ * @param session Session to check.
+ * 
+ * @return        String with socket type.
+ * @return        @c NULL , if error occured.
+ */
+const char *jcon_socket_getSocketType(jcon_socket_t *session);
+
+/**
+ * @brief Returns string with connection information.
+ * 
+ * <b>Example:</b> "TCP:127.0.0.1:8080"
+ * <b>Example:</b> "UNIX:/tmp/test.uds"
+ * 
+ * @param session Session to check.
+ * 
+ * @return        String with connection info.
+ * @return        @c NULL , if error occured.
+ */
+const char *jcon_socket_getReferenceString(jcon_socket_t *session);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDE_JCON_SOCKET_H */

--- a/inc/jayc/jcon_socketTCP.h
+++ b/inc/jayc/jcon_socketTCP.h
@@ -34,7 +34,7 @@ extern "C" {
  * @return        Session object.
  * @return        @c NULL , if error occured.
  */
-jcon_socket_t *jcon_socketTCP_simpleInit(const char *address, uint16_t port, jlog_t *logger);
+jcon_socket_t *jcon_socketTCP_simple_init(const char *address, uint16_t port, jlog_t *logger);
 
 #ifdef __cplusplus
 }

--- a/inc/jayc/jcon_socketTCP.h
+++ b/inc/jayc/jcon_socketTCP.h
@@ -1,0 +1,44 @@
+/**
+ * @file jcon_socketTCP.h
+ * @author Manuel Nadji (https://github.com/gnarrf95)
+ * 
+ * @brief TCP variant of jcon_socket.
+ * 
+ * @date 2020-10-06
+ * @copyright Copyright (c) 2020 by Manuel Nadji
+ * 
+ */
+
+#ifndef INCLUDE_JCON_SOCKETTCP_H
+#define INCLUDE_JCON_SOCKETTCP_H
+
+#include <jayc/jcon_socket.h>
+#include <jayc/jcon_socket_dev.h>
+#include <netinet/in.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Simple initializer. Only essential information needed.
+ * 
+ * TCP/IP stack provides a lot of options and flags to
+ * initialize and manage a socket.
+ * This function only requires the bare minimum to create
+ * a connection.
+ * 
+ * @param address IP/DNS address of server to connect to.
+ * @param port    Port to connect to.
+ * @param logger  Logger to use in session.
+ * 
+ * @return        Session object.
+ * @return        @c NULL , if error occured.
+ */
+jcon_socket_t *jcon_socketTCP_simpleInit(const char *address, uint16_t port, jlog_t *logger);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDE_JCON_SOCKETTCP_H */

--- a/inc/jayc/jcon_socketUnix.h
+++ b/inc/jayc/jcon_socketUnix.h
@@ -22,19 +22,18 @@ extern "C" {
 /**
  * @brief Simple initializer. Only essential information needed.
  * 
- * Unix/IP stack provides a lot of options and flags to
+ * Unix socket stack provides a lot of options and flags to
  * initialize and manage a socket.
  * This function only requires the bare minimum to create
  * a connection.
  * 
- * @param address IP/DNS address of server to connect to.
- * @param port    Port to connect to.
- * @param logger  Logger to use in session.
+ * @param filepath  Path to UDS file.
+ * @param logger    Logger to use in session.
  * 
- * @return        Session object.
- * @return        @c NULL , if error occured.
+ * @return          Session object.
+ * @return          @c NULL , if error occured.
  */
-jcon_socket_t *jcon_socketUnix_simpleInit(const char *filepath, jlog_t *logger);
+jcon_socket_t *jcon_socketUnix_simple_init(const char *filepath, jlog_t *logger);
 
 #ifdef __cplusplus
 }

--- a/inc/jayc/jcon_socketUnix.h
+++ b/inc/jayc/jcon_socketUnix.h
@@ -1,16 +1,16 @@
 /**
- * @file jcon_socketTCP.h
+ * @file jcon_socketUnix.h
  * @author Manuel Nadji (https://github.com/gnarrf95)
  * 
- * @brief TCP variant of jcon_socket.
+ * @brief Unix variant of jcon_socket.
  * 
  * @date 2020-10-06
  * @copyright Copyright (c) 2020 by Manuel Nadji
  * 
  */
 
-#ifndef INCLUDE_JCON_SOCKETTCP_H
-#define INCLUDE_JCON_SOCKETTCP_H
+#ifndef INCLUDE_JCON_SOCKETUNIX_H
+#define INCLUDE_JCON_SOCKETUNIX_H
 
 #include <jayc/jcon_socket.h>
 #include <jayc/jlog.h>
@@ -22,7 +22,7 @@ extern "C" {
 /**
  * @brief Simple initializer. Only essential information needed.
  * 
- * TCP/IP stack provides a lot of options and flags to
+ * Unix/IP stack provides a lot of options and flags to
  * initialize and manage a socket.
  * This function only requires the bare minimum to create
  * a connection.
@@ -34,10 +34,10 @@ extern "C" {
  * @return        Session object.
  * @return        @c NULL , if error occured.
  */
-jcon_socket_t *jcon_socketTCP_simpleInit(const char *address, uint16_t port, jlog_t *logger);
+jcon_socket_t *jcon_socketUnix_simpleInit(const char *filepath, jlog_t *logger);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* INCLUDE_JCON_SOCKETTCP_H */
+#endif /* INCLUDE_JCON_SOCKETUnix_H */

--- a/inc/jayc/jcon_socket_dev.h
+++ b/inc/jayc/jcon_socket_dev.h
@@ -1,0 +1,119 @@
+/**
+ * @file jcon_socket_dev.h
+ * @author Manuel Nadji (https://github.com/gnarrf95)
+ * 
+ * @brief Necessary definition for implementations of jcon_socket.
+ * 
+ * @date 2020-10-05
+ * @copyright Copyright (c) 2020 by Manuel Nadji
+ * 
+ */
+
+#ifndef INCLUDE_JCON_SOCKET_DEV_H
+#define INCLUDE_JCON_SOCKET_DEV_H
+
+#include <jayc/jcon_socket.h>
+#include <jayc/jlog.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief The connection type is not defined yet.
+ * 
+ * In case socket is not yet created or closed.
+ */
+#define JCON_SOCKET_CONNECTIONTYPE_NOTDEF 0
+
+/**
+ * @brief Socket operates as client.
+ * 
+ * Forbids session from using function
+ * @c #jcon_socket_accept() .
+ */
+#define JCON_SOCKET_CONNECTIONTYPE_CLIENT 1
+
+/**
+ * @brief Socket operates as server.
+ * 
+ * Forbids session from using functions
+ * @c #jcon_socket_recvData() and @c #jcon_socket_sendData() .
+ */
+#define JCON_SOCKET_CONNECTIONTYPE_SERVER 2
+
+/**
+ * @brief Handler function to connect socket.
+ * 
+ * @param session Session to connect.
+ * 
+ * @return        @c true , if successfully connected.
+ * @return        @c false , if error occured.
+ */
+typedef int(*jcon_socket_connect_handler_t)(jcon_socket_t *session);
+
+/**
+ * @brief Handler function to bind socket.
+ * 
+ * @param session Session to bind.
+ * 
+ * @return        @c true , if successfully bound.
+ * @return        @c false , if error occured.
+ */
+typedef int(*jcon_socket_bind_handler_t)(jcon_socket_t *session);
+
+/**
+ * @brief Handler function to do cleanup before socket descriptor is closed.
+ * 
+ * @param session Session to connect.
+ */
+typedef void(*jcon_socket_close_handler_t)(jcon_socket_t *session);
+
+/**
+ * @brief Handler function to accept connection.
+ * 
+ * @param session Session to accept connection.
+ * 
+ * @return        New connection session.
+ * @return        @c NULL , if error occured.
+ */
+typedef jcon_socket_t *(*jcon_socket_accept_handler_t)(jcon_socket_t *session);
+
+/**
+ * @brief Handler function to free session memory.
+ * 
+ * @param session Session to free.
+ */
+typedef void(*jcon_socket_free_handler_t)(jcon_socket_t *session);
+
+/**
+ * @brief Session object.
+ * 
+ * Holds data for socket operation.
+ */
+struct __jcon_socket_session
+{
+  int file_descriptor;                              /**< File descriptor for socket. */
+  int connection_type;                              /**< Enumeration with values:
+                                                         * @c #JCON_SOCKET_CONNECTIONTYPE_NETDEF ,
+                                                         * @c #JCON_SOCKET_CONNECTIONTYPE_CLIENT ,
+                                                         * @c #JCON_SOCKET_CONNECTIONTYPE_SERVER . */
+                                                      
+  char *socket_type;                                /**< Tells what kind of socket it is. */
+  char *referenceString;                            /**< Holds information about connection. */
+  jlog_t *logger;                                   /**< Logger to use for debug and error output. */
+
+  jcon_socket_connect_handler_t function_connect;   /**< Handler to be called by @c #jcon_socket_connect() . */
+  jcon_socket_bind_handler_t function_bind;         /**< Handler to be called by @c #jcon_socket_bind() . */
+  jcon_socket_close_handler_t function_close;       /**< Handler to be called by @c #jcon_socket_close() . */
+  jcon_socket_accept_handler_t function_accept;     /**< Handler to be called by @c #jcon_socket_accept() . */
+  jcon_socket_free_handler_t session_free_handler;  /**< Handler to be called by @c #jcon_socket_free() . */
+
+  void *session_ctx;                                /**< Session context used for implementations. */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* INCLUDE_JCON_SOCKET_DEV_H */

--- a/src/jcon/jcon_client_tcp.c
+++ b/src/jcon/jcon_client_tcp.c
@@ -11,7 +11,6 @@
 
 #include <jayc/jcon_client_tcp.h>
 #include <jayc/jcon_client_dev.h>
-#include <jayc/jcon_tcp.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -171,7 +170,7 @@ static void jcon_client_tcp_log(void *ctx, int log_type, const char *file, const
  */
 typedef struct __jcon_client_tcp_context
 {
-  jcon_tcp_t *connection;             /**< jcon_tcp session object. */
+  jcon_socket_t *connection;             /**< jcon_tcp session object. */
   int poll_timeout;                   /**< Timeout for asking for new data in milliseconds. */
   jlog_t *logger;                     /**< Logger for debug and error messages. */
 } jcon_client_tcp_context_t;
@@ -215,10 +214,10 @@ jcon_client_t *jcon_client_tcp_session_init(char *address, uint16_t port, jlog_t
   ctx->poll_timeout = JCON_CLIENT_TCP_POLL_TIMEOUT_DEFAULT;
   ctx->logger = logger;
 
-  ctx->connection = jcon_tcp_simple_init(address, port, logger);
+  ctx->connection = jcon_socketTCP_simple_init(address, port, logger);
   if(ctx->connection == NULL)
   {
-    ERROR(NULL, "<TCP:%s:%u> jcon_tcp_simple_init() failed. Destroying context and session.", address, port);
+    ERROR(NULL, "<TCP:%s:%u> jcon_socketTCP_simple_init() failed. Destroying context and session.", address, port);
     free(ctx);
     free(session);
     return NULL;
@@ -229,7 +228,7 @@ jcon_client_t *jcon_client_tcp_session_init(char *address, uint16_t port, jlog_t
 
 //------------------------------------------------------------------------------
 //
-jcon_client_t *jcon_client_tcp_session_tcpClone(jcon_tcp_t *tcp_session, jlog_t *logger)
+jcon_client_t *jcon_client_tcp_session_tcpClone(jcon_socket_t *tcp_session, jlog_t *logger)
 {
   if(tcp_session == NULL)
   {
@@ -283,7 +282,7 @@ void jcon_client_tcp_session_free(void *ctx)
   jcon_client_tcp_close(ctx);
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
 
-  jcon_tcp_free(session_context->connection);
+  jcon_socket_free(session_context->connection);
   free(ctx);
 }
 
@@ -304,9 +303,9 @@ int jcon_client_tcp_reset(void *ctx)
 
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
 
-  if(jcon_tcp_connect(session_context->connection) == false)
+  if(jcon_socket_connect(session_context->connection) == false)
   {
-    ERROR(ctx, "jcon_tcp_connect() failed.");
+    ERROR(ctx, "jcon_socket_connect() failed.");
     return false;
   }
   
@@ -331,7 +330,7 @@ void jcon_client_tcp_close(void *ctx)
     return;
   }
 
-  jcon_tcp_close(session_context->connection);
+  jcon_socket_close(session_context->connection);
 }
 
 //------------------------------------------------------------------------------
@@ -346,7 +345,7 @@ int jcon_client_tcp_isConnected(void *ctx)
 
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
 
-  return jcon_tcp_isConnected(session_context->connection);
+  return jcon_socket_isConnected(session_context->connection);
 }
 
 //------------------------------------------------------------------------------
@@ -361,7 +360,7 @@ const char *jcon_client_tcp_getReferenceString(void *ctx)
 
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
 
-  return jcon_tcp_getReferenceString(session_context->connection);
+  return jcon_socket_getReferenceString(session_context->connection);
 }
 
 //------------------------------------------------------------------------------
@@ -376,7 +375,7 @@ int jcon_client_tcp_newData(void *ctx)
 
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
 
-  return jcon_tcp_pollForInput(session_context->connection, session_context->poll_timeout);
+  return jcon_socket_pollForInput(session_context->connection, session_context->poll_timeout);
 }
 
 //------------------------------------------------------------------------------
@@ -391,7 +390,7 @@ size_t jcon_client_tcp_recvData(void *ctx, void *data_ptr, size_t data_size)
 
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
 
-  return jcon_tcp_recvData(session_context->connection, data_ptr, data_size);
+  return jcon_socket_recvData(session_context->connection, data_ptr, data_size);
 }
 
 //------------------------------------------------------------------------------
@@ -406,7 +405,7 @@ size_t jcon_client_tcp_sendData(void *ctx, void *data_ptr, size_t data_size)
 
   jcon_client_tcp_context_t *session_context = (jcon_client_tcp_context_t *)ctx;
   
-  return jcon_tcp_sendData(session_context->connection, data_ptr, data_size);
+  return jcon_socket_sendData(session_context->connection, data_ptr, data_size);
 }
 
 //------------------------------------------------------------------------------

--- a/src/jcon/jcon_client_unix.c
+++ b/src/jcon/jcon_client_unix.c
@@ -171,7 +171,7 @@ static void jcon_client_unix_log(void *ctx, int log_type, const char *file, cons
  */
 typedef struct __jcon_client_unix_context
 {
-  jcon_unix_t *connection;            /**< jcon_unix session object. */
+  jcon_socket_t *connection;            /**< jcon_unix session object. */
   int poll_timeout;                   /**< Timeout for asking for new data in milliseconds. */
   jlog_t *logger;                     /**< Logger for debug and error messages. */
 } jcon_client_unix_context_t;
@@ -215,10 +215,10 @@ jcon_client_t *jcon_client_unix_session_init(char *filepath, jlog_t *logger)
   ctx->poll_timeout = JCON_CLIENT_UNIX_POLL_TIMEOUT_DEFAULT;
   ctx->logger = logger;
 
-  ctx->connection = jcon_unix_simple_init(filepath, logger);
+  ctx->connection = jcon_socketUnix_simple_init(filepath, logger);
   if(ctx->connection == NULL)
   {
-    ERROR(NULL, "<UNIX:%s> jcon_unix_simple_init() failed. Destroying context and session.", filepath);
+    ERROR(NULL, "<UNIX:%s> jcon_socketUnix_simple_init() failed. Destroying context and session.", filepath);
     free(ctx);
     free(session);
     return NULL;
@@ -229,7 +229,7 @@ jcon_client_t *jcon_client_unix_session_init(char *filepath, jlog_t *logger)
 
 //------------------------------------------------------------------------------
 //
-jcon_client_t *jcon_client_unix_session_unixClone(jcon_unix_t *unix_session, jlog_t *logger)
+jcon_client_t *jcon_client_unix_session_unixClone(jcon_socket_t *unix_session, jlog_t *logger)
 {
   if(unix_session == NULL)
   {
@@ -283,7 +283,7 @@ void jcon_client_unix_session_free(void *ctx)
   jcon_client_unix_close(ctx);
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
 
-  jcon_unix_free(session_context->connection);
+  jcon_socket_free(session_context->connection);
   free(ctx);
 }
 
@@ -304,7 +304,7 @@ int jcon_client_unix_reset(void *ctx)
 
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
 
-  if(jcon_unix_connect(session_context->connection) == false)
+  if(jcon_socket_connect(session_context->connection) == false)
   {
     ERROR(ctx, "jcon_unix_connect() failed.");
     return false;
@@ -331,7 +331,7 @@ void jcon_client_unix_close(void *ctx)
     return;
   }
 
-  jcon_unix_close(session_context->connection);
+  jcon_socket_close(session_context->connection);
 }
 
 //------------------------------------------------------------------------------
@@ -346,7 +346,7 @@ int jcon_client_unix_isConnected(void *ctx)
 
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
 
-  return jcon_unix_isConnected(session_context->connection);
+  return jcon_socket_isConnected(session_context->connection);
 }
 
 //------------------------------------------------------------------------------
@@ -361,7 +361,7 @@ const char *jcon_client_unix_getReferenceString(void *ctx)
 
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
 
-  return jcon_unix_getReferenceString(session_context->connection);
+  return jcon_socket_getReferenceString(session_context->connection);
 }
 
 //------------------------------------------------------------------------------
@@ -376,7 +376,7 @@ int jcon_client_unix_newData(void *ctx)
 
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
 
-  return jcon_unix_pollForInput(session_context->connection, session_context->poll_timeout);
+  return jcon_socket_pollForInput(session_context->connection, session_context->poll_timeout);
 }
 
 //------------------------------------------------------------------------------
@@ -391,7 +391,7 @@ size_t jcon_client_unix_recvData(void *ctx, void *data_ptr, size_t data_size)
 
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
 
-  return jcon_unix_recvData(session_context->connection, data_ptr, data_size);
+  return jcon_socket_recvData(session_context->connection, data_ptr, data_size);
 }
 
 //------------------------------------------------------------------------------
@@ -406,7 +406,7 @@ size_t jcon_client_unix_sendData(void *ctx, void *data_ptr, size_t data_size)
 
   jcon_client_unix_context_t *session_context = (jcon_client_unix_context_t *)ctx;
   
-  return jcon_unix_sendData(session_context->connection, data_ptr, data_size);
+  return jcon_socket_sendData(session_context->connection, data_ptr, data_size);
 }
 
 //------------------------------------------------------------------------------

--- a/src/jcon/jcon_server_tcp.c
+++ b/src/jcon/jcon_server_tcp.c
@@ -12,7 +12,7 @@
 #include <jayc/jcon_server_tcp.h>
 #include <jayc/jcon_server_dev.h>
 #include <jayc/jcon_client_tcp.h>
-#include <jayc/jcon_tcp.h>
+#include <jayc/jcon_socketTCP.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -158,7 +158,7 @@ static void jcon_server_tcp_log(void *ctx, int log_type, const char *file, const
  */
 typedef struct __jcon_server_tcp_context
 {
-  jcon_tcp_t *server;                 /**< jcon_tcp session object. */
+  jcon_socket_t *server;                 /**< jcon_tcp session object. */
   int poll_timeout;                   /**< Timeout for asking for new data in milliseconds. */
   jlog_t *logger;                     /**< Logger for debug and error messages. */
 } jcon_server_tcp_context_t;
@@ -201,10 +201,10 @@ jcon_server_t *jcon_server_tcp_session_init(char *address, uint16_t port, jlog_t
   ctx->poll_timeout = JCON_SERVER_TCP_POLL_TIMEOUT_DEFAULT;
   ctx->logger = logger;
 
-  ctx->server = jcon_tcp_simple_init(address, port, logger);
+  ctx->server = jcon_socketTCP_simple_init(address, port, logger);
   if(ctx->server == NULL)
   {
-    ERROR(NULL, "<TCP:%s:%u> json_client_tcp_createReferenceString() failed. Destroying context and session.", address, port);
+    ERROR(NULL, "<TCP:%s:%u> jcon_socketTCP_simple_init() failed. Destroying context and session.", address, port);
     free(ctx);
     free(session);
     return NULL;
@@ -229,7 +229,7 @@ void jcon_server_tcp_session_free(void *ctx)
   }
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
-  jcon_tcp_free(session_context->server);
+  jcon_socket_free(session_context->server);
 
   free(ctx);
 }
@@ -251,7 +251,7 @@ int jcon_server_tcp_reset(void *ctx)
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
 
-  return jcon_tcp_bind(session_context->server);
+  return jcon_socket_bind(session_context->server);
 }
 
 //------------------------------------------------------------------------------
@@ -272,7 +272,7 @@ void jcon_server_tcp_close(void *ctx)
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
 
-  jcon_tcp_close(session_context->server);
+  jcon_socket_close(session_context->server);
 }
 
 
@@ -288,7 +288,7 @@ int jcon_server_tcp_isOpen(void *ctx)
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
 
-  return jcon_tcp_isConnected(session_context->server);
+  return jcon_socket_isConnected(session_context->server);
 }
 
 //------------------------------------------------------------------------------
@@ -303,7 +303,7 @@ const char *jcon_server_tcp_getReferenceString(void *ctx)
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
 
-  return jcon_tcp_getReferenceString(session_context->server);
+  return jcon_socket_getReferenceString(session_context->server);
 }
 
 //------------------------------------------------------------------------------
@@ -318,7 +318,7 @@ int jcon_server_tcp_newConnection(void *ctx)
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
 
-  return jcon_tcp_pollForInput(session_context->server, session_context->poll_timeout);
+  return jcon_socket_pollForInput(session_context->server, session_context->poll_timeout);
 }
 
 //------------------------------------------------------------------------------
@@ -333,7 +333,7 @@ jcon_client_t *jcon_server_tcp_acceptConnection(void *ctx)
 
   jcon_server_tcp_context_t *session_context = (jcon_server_tcp_context_t *)ctx;
 
-  jcon_tcp_t *new_connection = jcon_tcp_accept(session_context->server);
+  jcon_socket_t *new_connection = jcon_socket_accept(session_context->server);
   if(new_connection == NULL)
   {
     ERROR(ctx, "jcon_tcp_accept() failed.");
@@ -344,7 +344,7 @@ jcon_client_t *jcon_server_tcp_acceptConnection(void *ctx)
   if(new_client == NULL)
   {
     ERROR(ctx, "jcon_client_tcp_session_tcpClone() failed.");
-    jcon_tcp_free(new_connection);
+    jcon_socket_free(new_connection);
     return NULL;
   }
 

--- a/src/jcon/jcon_server_unix.c
+++ b/src/jcon/jcon_server_unix.c
@@ -12,7 +12,7 @@
 #include <jayc/jcon_server_unix.h>
 #include <jayc/jcon_server_dev.h>
 #include <jayc/jcon_client_unix.h>
-#include <jayc/jcon_unix.h>
+#include <jayc/jcon_socketUnix.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -158,7 +158,7 @@ static void jcon_server_unix_log(void *ctx, int log_type, const char *file, cons
  */
 typedef struct __jcon_server_unix_context
 {
-  jcon_unix_t *server;                 /**< jcon_unix session object. */
+  jcon_socket_t *server;                 /**< jcon_unix session object. */
   int poll_timeout;                   /**< Timeout for asking for new data in milliseconds. */
   jlog_t *logger;                     /**< Logger for debug and error messages. */
 } jcon_server_unix_context_t;
@@ -201,10 +201,10 @@ jcon_server_t *jcon_server_unix_session_init(char *filepath, jlog_t *logger)
   ctx->poll_timeout = JCON_SERVER_UNIX_POLL_TIMEOUT_DEFAULT;
   ctx->logger = logger;
 
-  ctx->server = jcon_unix_simple_init(filepath, logger);
+  ctx->server = jcon_socketUnix_simple_init(filepath, logger);
   if(ctx->server == NULL)
   {
-    ERROR(NULL, "<UNIX:%s> json_client_unix_createReferenceString() failed. Destroying context and session.", filepath);
+    ERROR(NULL, "<UNIX:%s> jcon_socketUnix_simple_init() failed. Destroying context and session.", filepath);
     free(ctx);
     free(session);
     return NULL;
@@ -229,7 +229,7 @@ void jcon_server_unix_session_free(void *ctx)
   }
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
-  jcon_unix_free(session_context->server);
+  jcon_socket_free(session_context->server);
 
   free(ctx);
 }
@@ -251,7 +251,7 @@ int jcon_server_unix_reset(void *ctx)
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
 
-  return jcon_unix_bind(session_context->server);
+  return jcon_socket_bind(session_context->server);
 }
 
 //------------------------------------------------------------------------------
@@ -272,7 +272,7 @@ void jcon_server_unix_close(void *ctx)
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
 
-  jcon_unix_close(session_context->server);
+  jcon_socket_close(session_context->server);
 }
 
 
@@ -288,7 +288,7 @@ int jcon_server_unix_isOpen(void *ctx)
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
 
-  return jcon_unix_isConnected(session_context->server);
+  return jcon_socket_isConnected(session_context->server);
 }
 
 //------------------------------------------------------------------------------
@@ -303,7 +303,7 @@ const char *jcon_server_unix_getReferenceString(void *ctx)
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
 
-  return jcon_unix_getReferenceString(session_context->server);
+  return jcon_socket_getReferenceString(session_context->server);
 }
 
 //------------------------------------------------------------------------------
@@ -318,7 +318,7 @@ int jcon_server_unix_newConnection(void *ctx)
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
 
-  return jcon_unix_pollForInput(session_context->server, session_context->poll_timeout);
+  return jcon_socket_pollForInput(session_context->server, session_context->poll_timeout);
 }
 
 //------------------------------------------------------------------------------
@@ -333,7 +333,7 @@ jcon_client_t *jcon_server_unix_acceptConnection(void *ctx)
 
   jcon_server_unix_context_t *session_context = (jcon_server_unix_context_t *)ctx;
 
-  jcon_unix_t *new_connection = jcon_unix_accept(session_context->server);
+  jcon_socket_t *new_connection = jcon_socket_accept(session_context->server);
   if(new_connection == NULL)
   {
     ERROR(ctx, "jcon_unix_accept() failed.");
@@ -344,7 +344,7 @@ jcon_client_t *jcon_server_unix_acceptConnection(void *ctx)
   if(new_client == NULL)
   {
     ERROR(ctx, "jcon_client_unix_session_unixClone() failed.");
-    jcon_unix_free(new_connection);
+    jcon_socket_free(new_connection);
     return NULL;
   }
 

--- a/src/jcon/jcon_socket.c
+++ b/src/jcon/jcon_socket.c
@@ -1,0 +1,465 @@
+/**
+ * @file jcon_socket.c
+ * @author Manuel Nadji (https://github.com/gnarrf95)
+ * 
+ * @brief Implementation of jcon_socket.
+ * 
+ * @date 2020-10-05
+ * @copyright Copyright (c) 2020 by Manuel Nadji
+ * 
+ */
+
+#include <jayc/jcon_socket.h>
+#include <jayc/jcon_socket_dev.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <poll.h>
+
+//==============================================================================
+// Define Log function and macros.
+//
+
+/**
+ * @brief Sends log messages to logger with session data.
+ * 
+ * Uses logger. If available adds reference string to log messages.
+ * 
+ * @param session   Session object.
+ * @param log_type  (debug, info, warning, error, critical, fatal).
+ * @param file      Source code file.
+ * @param function  Function name.
+ * @param line      Line number of source file.
+ * @param fmt       String format for stdarg.h .
+ */
+static void jcon_socket_log(jcon_socket_t *session, int log_type, const char *file, const char *function, int line, const char *fmt, ...);
+
+#ifdef JCON_NO_DEBUG /* Allow to turn of debug messages at compile time. */
+  #define DEBUG(session, fmt, ...)
+#else
+  #define DEBUG(session, fmt, ...) jcon_socket_log(session, JLOG_LOGTYPE_DEBUG, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#endif
+#define INFO(session, fmt, ...) jcon_socket_log(session, JLOG_LOGTYPE_INFO, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define WARN(session, fmt, ...) jcon_socket_log(session, JLOG_LOGTYPE_WARN, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define ERROR(session, fmt, ...) jcon_socket_log(session, JLOG_LOGTYPE_ERROR, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define CRITICAL(session, fmt, ...) jcon_socket_log(session, JLOG_LOGTYPE_CRITICAL, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define FATAL(session, fmt, ...) jcon_socket_log(session, JLOG_LOGTYPE_FATAL, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+
+
+
+//==============================================================================
+// Implement interface functions.
+//
+
+//------------------------------------------------------------------------------
+//
+void jcon_socket_free(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return;
+  }
+
+  if(jcon_socket_isConnected(session))
+  {
+    jcon_socket_close(session);
+  }
+
+  if(session->session_free_handler)
+  {
+    session->session_free_handler(session);
+  }
+
+  free(session->referenceString);
+  free(session);
+}
+
+//------------------------------------------------------------------------------
+//
+int jcon_socket_connect(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return false;
+  }
+
+  if(jcon_socket_isConnected(session))
+  {
+    DEBUG(session, "Session is already connected.");
+    return true;
+  }
+
+  if(session->function_connect == NULL)
+  {
+    ERROR(session, "function_connect() is NULL.");
+    return false;
+  }
+
+  if(session->function_connect(session) == false)
+  {
+    DEBUG(session, "function_connect() failed.");
+    return false;
+  }
+
+  session->connection_type = JCON_SOCKET_CONNECTIONTYPE_CLIENT;
+  return true;
+}
+
+//------------------------------------------------------------------------------
+//
+int jcon_socket_bind(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return false;
+  }
+
+  if(jcon_socket_isConnected(session))
+  {
+    DEBUG(session, "Session is already connected.");
+    return true;
+  }
+
+  if(session->function_bind == NULL)
+  {
+    ERROR(session, "function_bind() is NULL.");
+    return false;
+  }
+
+  if(session->function_bind(session) == false)
+  {
+    DEBUG(session, "function_bind() failed.");
+    return false;
+  }
+
+  session->connection_type = JCON_SOCKET_CONNECTIONTYPE_SERVER;
+  return true;
+}
+
+//------------------------------------------------------------------------------
+//
+void jcon_socket_close(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return;
+  }
+
+  if(jcon_socket_isConnected(session) == false)
+  {
+    DEBUG(session, "Session is already closed.");
+    return;
+  }
+
+  if(session->function_close)
+  {
+    session->function_close(session);
+  }
+
+  if(close(session->file_descriptor) < 0)
+  {
+    ERROR(session, "close() failed [%d : %s].", errno, strerror(errno));
+  }
+
+  session->file_descriptor = 0;
+  session->connection_type = JCON_SOCKET_CONNECTIONTYPE_NOTDEF;
+}
+
+//------------------------------------------------------------------------------
+//
+int jcon_socket_pollForInput(jcon_socket_t *session, int timeout)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return false;
+  }
+
+  if(jcon_socket_isConnected(session) == false)
+  {
+    ERROR(session, "Session is not connected.");
+    return false;
+  }
+
+  struct pollfd poll_fds[1];
+  poll_fds->fd = session->file_descriptor;
+  poll_fds->events = POLLIN;
+
+  int ret_poll = poll(poll_fds, 1, timeout);
+
+  if(ret_poll < 0)
+  {
+    ERROR(session, "poll() failed [%d : %s].", errno, strerror(errno));
+    return false;
+  }
+
+  if(ret_poll == 0)
+  {
+    return false;
+  }
+
+  int ret = true;
+
+  if(poll_fds->revents & POLLERR)
+  {
+    DEBUG(session, "poll() recieved [POLLERR].");
+    jcon_socket_close(session);
+    ret = false;
+  }
+  if(poll_fds->revents & POLLNVAL)
+  {
+    DEBUG(session, "poll() recieved [POLLNVAL].");
+    ret = false;
+  }
+  if(poll_fds->revents & POLLIN)
+  {
+    DEBUG(session, "poll() recieved [POLLIN].");
+  }
+  if(poll_fds->revents & POLLHUP)
+  {
+    DEBUG(session, "poll() recieved [POLLHUP].");
+  }
+
+  return ret;
+}
+
+//------------------------------------------------------------------------------
+//
+jcon_socket_t *jcon_socket_accept(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return NULL;
+  }
+
+  if(session->connection_type != JCON_SOCKET_CONNECTIONTYPE_SERVER)
+  {
+    ERROR(session, "Session is not of type server.");
+    return NULL;
+  }
+
+  if(jcon_socket_isConnected(session) == false)
+  {
+    ERROR(session, "Session is not connected.");
+    return NULL;
+  }
+
+  if(session->function_accept == NULL)
+  {
+    ERROR(session, "function_accept() is NULL.");
+    return NULL;
+  }
+
+  jcon_socket_t *new_session = session->function_accept(session);
+  if(new_session == NULL)
+  {
+    DEBUG(session, "function_accept() failed.");
+    return NULL;
+  }
+
+  return new_session;
+}
+
+//------------------------------------------------------------------------------
+//
+size_t jcon_socket_recvData(jcon_socket_t *session, void *data_ptr, size_t data_size)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return 0;
+  }
+
+  if(jcon_socket_isConnected(session) == false)
+  {
+    ERROR(session, "Session is not connected.");
+    return 0;
+  }
+
+  if(session->connection_type != JCON_SOCKET_CONNECTIONTYPE_CLIENT)
+  {
+    ERROR(session, "Session is not of type client.");
+    return 0;
+  }
+
+  if(data_size == 0)
+  {
+    ERROR(session, "data_size given is [0].");
+    return 0;
+  }
+
+  void *buf = malloc(data_size);
+  if(buf == NULL)
+  {
+    ERROR(session, "malloc() failed.");
+    return 0;
+  }
+
+  int ret_recv = recv(session->file_descriptor, buf, data_size, 0);
+  if(ret_recv < 0)
+  {
+    ERROR(session, "recv() failed [%d : %s].", errno, strerror(errno));
+    free(buf);
+    return 0;
+  }
+
+  if(ret_recv == 0)
+  {
+    DEBUG(session, "recv() returned [0]. Closing connection.");
+    jcon_socket_close(session);
+    free(buf);
+    return 0;
+  }
+
+  size_t cpy_size = ret_recv;
+
+  /* Potential for buffer overflow. Checking and trimming data if necessary. */
+  if(ret_recv > data_size)
+  {
+    DEBUG(session, "Buffer overflow detected [%d > %d]. Trimming data.", ret_recv, data_size);
+    cpy_size = data_size;
+  }
+
+  if(data_ptr)
+  {
+    memcpy(data_ptr, buf, cpy_size);
+  }
+  free(buf);
+
+  return cpy_size;
+}
+
+//------------------------------------------------------------------------------
+//
+size_t jcon_socket_sendData(jcon_socket_t *session, void *data_ptr, size_t data_size)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return 0;
+  }
+
+  if(jcon_socket_isConnected(session) == false)
+  {
+    ERROR(session, "Session is not connected.");
+    return 0;
+  }
+
+  if(session->connection_type != JCON_SOCKET_CONNECTIONTYPE_CLIENT)
+  {
+    ERROR(session, "Session is not of type client.");
+    return 0;
+  }
+
+  if(data_ptr == NULL)
+  {
+    ERROR(session, "data_ptr is NULL.");
+    return 0;
+  }
+
+  if(data_size == 0)
+  {
+    ERROR(session, "data_size given is [0].");
+    return 0;
+  }
+
+  /* Fixed broken pipe termination, by preventing SIGPIPE. */
+  int ret_send = send(session->file_descriptor, data_ptr, data_size, MSG_NOSIGNAL);
+  if(ret_send < 0)
+  {
+    if(errno == ECONNRESET || errno == EPIPE)
+    {
+      jcon_socket_close(session);
+    }
+    else
+    {
+      ERROR(session, "send() failed [%d : %s].", errno, strerror(errno));
+    }
+    return 0;
+  }
+
+  return ret_send;
+}
+
+//------------------------------------------------------------------------------
+//
+int jcon_socket_isConnected(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return false;
+  }
+
+  return (session->file_descriptor > 0);
+}
+
+//------------------------------------------------------------------------------
+//
+const char *jcon_socket_getSocketType(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return NULL;
+  }
+
+  return session->socket_type;
+}
+
+//------------------------------------------------------------------------------
+//
+const char *jcon_socket_getReferenceString(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return NULL;
+  }
+
+  return session->referenceString;
+}
+
+
+
+//==============================================================================
+// Implement log function.
+//
+
+//------------------------------------------------------------------------------
+//
+void jcon_socket_log(jcon_socket_t *session, int log_type, const char *file, const char *function, int line, const char *fmt, ...)
+{
+  va_list args;
+  char buf[2048];
+
+  va_start(args, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, args);
+  va_end(args);
+
+  if(session)
+  {
+    if(session->logger)
+    {
+      jlog_log_message_m(session->logger, log_type, file, function, line, "<%s> %s", jcon_socket_getReferenceString(session), buf);
+    }
+    else
+    {
+      jlog_global_log_message_m(log_type, file, function, line, "<%s> %s", jcon_socket_getReferenceString(session), buf);
+    }
+  }
+  else
+  {
+    jlog_global_log_message_m(log_type, file, function, line, buf);
+  }
+}

--- a/src/jcon/jcon_socketTCP.c
+++ b/src/jcon/jcon_socketTCP.c
@@ -181,7 +181,7 @@ static void jcon_socketTCP_log(jcon_socket_t *session, int log_type, const char 
 
 //------------------------------------------------------------------------------
 //
-jcon_socket_t *jcon_socketTCP_simpleInit(const char *address, uint16_t port, jlog_t *logger)
+jcon_socket_t *jcon_socketTCP_simple_init(const char *address, uint16_t port, jlog_t *logger)
 {
   jcon_socket_t *session = (jcon_socket_t *)malloc(sizeof(jcon_socket_t));
   if(session == NULL)

--- a/src/jcon/jcon_socketTCP.c
+++ b/src/jcon/jcon_socketTCP.c
@@ -1,0 +1,524 @@
+/**
+ * @file jcon_socketTCP.c
+ * @author Manuel Nadji (https://github.com/gnarrf95)
+ * 
+ * @brief Implementations for jcon_socketTCP.
+ * 
+ * @date 2020-10-06
+ * @copyright Copyright (c) 2020 by Manuel Nadji
+ * 
+ */
+
+#include <jayc/jcon_socketTCP.h>
+#include <jayc/jcon_socket_dev.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+//==============================================================================
+// Define constants and structures.
+//
+
+#define JCON_SOCKETTCP_CONNECTIONTYPE "TCP"
+
+/**
+ * @brief Session context for TCP sockets.
+ * 
+ */
+typedef struct __jcon_socketTCP_context
+{
+  struct sockaddr_in socket_address;  /**< Address struct. */
+} jcon_socketTCP_ctx_t;
+
+
+
+//==============================================================================
+// Declare internal functions.
+//
+
+/**
+ * @brief Creates session from existing socket.
+ * 
+ * Used by @c #jcon_socketTCP_accept() .
+ * If server accepts new client, the connection to said
+ * client is made into new session.
+ * 
+ * @param fd              File descriptor of new socket.
+ * @param socket_address  Address struct of new socket.
+ * @param logger          Logger for new session.
+ * 
+ * @return                Session object for new client connection.
+ * @return                @c NULL in case of error.
+ */
+static jcon_socket_t *jcon_socketTCP_clone(int fd, struct sockaddr_in socket_address, jlog_t *logger);
+
+/**
+ * @brief Frees session memory.
+ * 
+ * Called by @c #jcon_socket_free() .
+ * 
+ * @param session Session object to free.
+ */
+static void jcon_socketTCP_free(jcon_socket_t *session);
+
+/**
+ * @brief Connect to server.
+ * 
+ * Called by @c #jcon_socket_connect() .
+ * 
+ * @param session Session to connect.
+ * 
+ * @return        @c true , if connection was established.
+ * @return        @c false , if connection failed.
+ */
+static int jcon_socketTCP_connect(jcon_socket_t *session);
+
+/**
+ * @brief Binds socket to address.
+ * 
+ * Called by @c #jcon_socket_bind() .
+ * 
+ * @param session Session to bind.
+ * 
+ * @return        @c true , if socket was bound to address.
+ * @return        @c false , if binding failed.
+ */
+static int jcon_socketTCP_bind(jcon_socket_t *session);
+
+/**
+ * @brief Accepts connection request.
+ * 
+ * Called by @c #jcon_socket_accept() .
+ * 
+ * @param session Server session, to accept connection.
+ * 
+ * @return        Session object of client connection.
+ * @return        @c NULL , if no new connection was
+ *                available or error occured.
+ */
+static jcon_socket_t *jcon_socketTCP_accept(jcon_socket_t *session);
+
+/**
+ * @brief Extract IP address from address struct.
+ * 
+ * @param socket_address  Address struct.
+ * 
+ * @return                String with IP address.
+ * @return                @c NULL in case of error.
+ */
+static char *jcon_socketTCP_getIP(struct sockaddr_in socket_address);
+
+/**
+ * @brief Extract port number from address struct. 
+ * 
+ * @param socket_address  Address struct.
+ * 
+ * @return                Port number.
+ * @return                @c 0 in case of error.
+ */
+static uint16_t jcon_socketTCP_getPort(struct sockaddr_in socket_address);
+
+/**
+ * @brief Create reference string from socket address.
+ * 
+ * Reference string consists of connection type (TCP),
+ * IP address ( @c #jcon_tcp_getIP() ) and port number
+ * ( @c #jcon_tcp_getPort() ).
+ * 
+ * These items get combined into one string.
+ * 
+ * @param socket_address  Address struct.
+ * 
+ * @return                Allocated reference string.
+ * @return                @c NULL in case of error.
+ */
+static char *jcon_socketTCP_createReferenceString(struct sockaddr_in socket_address);
+
+/**
+ * @brief Sends log messages to logger with session data.
+ * 
+ * Uses logger. If available adds reference string to log messages.
+ * 
+ * @param session   Session object.
+ * @param log_type  (debug, info, warning, error, critical, fatal).
+ * @param file      Source code file.
+ * @param function  Function name.
+ * @param line      Line number of source file.
+ * @param fmt       String format for stdarg.h .
+ */
+static void jcon_socketTCP_log(jcon_socket_t *session, int log_type, const char *file, const char *function, int line, const char *fmt, ...);
+
+
+
+//==============================================================================
+// Define log macros.
+//
+
+#ifdef JCON_NO_DEBUG /* Allow to turn of debug messages at compile time. */
+  #define DEBUG(session, fmt, ...)
+#else
+  #define DEBUG(session, fmt, ...) jcon_socketTCP_log(session, JLOG_LOGTYPE_DEBUG, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#endif
+#define INFO(session, fmt, ...) jcon_socketTCP_log(session, JLOG_LOGTYPE_INFO, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define WARN(session, fmt, ...) jcon_socketTCP_log(session, JLOG_LOGTYPE_WARN, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define ERROR(session, fmt, ...) jcon_socketTCP_log(session, JLOG_LOGTYPE_ERROR, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define CRITICAL(session, fmt, ...) jcon_socketTCP_log(session, JLOG_LOGTYPE_CRITICAL, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+#define FATAL(session, fmt, ...) jcon_socketTCP_log(session, JLOG_LOGTYPE_FATAL, __FILE__, __func__, __LINE__, fmt, ##__VA_ARGS__)
+
+
+
+//==============================================================================
+// Implement interface funcions.
+//
+
+//------------------------------------------------------------------------------
+//
+jcon_socket_t *jcon_socketTCP_simpleInit(const char *address, uint16_t port, jlog_t *logger)
+{
+  jcon_socket_t *session = (jcon_socket_t *)malloc(sizeof(jcon_socket_t));
+  if(session == NULL)
+  {
+    ERROR(NULL, "malloc() failed.");
+    return NULL;
+  }
+
+  session->function_connect = &jcon_socketTCP_connect;
+  session->function_bind = &jcon_socketTCP_bind;
+  session->function_close = NULL;
+  session->function_accept = &jcon_socketTCP_accept;
+  session->session_free_handler = &jcon_socketTCP_free;
+
+  session->file_descriptor = 0;
+  session->logger = logger;
+  session->socket_type = JCON_SOCKETTCP_CONNECTIONTYPE;
+  session->connection_type = 0;
+
+  jcon_socketTCP_ctx_t *ctx = (jcon_socketTCP_ctx_t *)malloc(sizeof(jcon_socketTCP_ctx_t));
+  if(ctx == NULL)
+  {
+    ERROR(NULL, "malloc() failed. Destroying session.");
+    free(session);
+    return NULL;
+  }
+
+  ctx->socket_address.sin_family = AF_INET;
+  ctx->socket_address.sin_port = htons(port);
+
+  struct hostent *hostinfo;
+  hostinfo = gethostbyname(address);
+  if(hostinfo == NULL)
+  {
+    ERROR(NULL, "<TCP:%s:%u> gethostbyname() failed. Destroying context and session.", address, port);
+    free(session);
+    return NULL;
+  }
+  ctx->socket_address.sin_addr = *(struct in_addr *)hostinfo->h_addr_list[0];
+
+  session->referenceString = jcon_socketTCP_createReferenceString(ctx->socket_address);
+  if(session->referenceString == NULL)
+  {
+    ERROR(NULL, "<TCP> jcon_tcp_createReferenceString() failed. Destroying session.");
+    free(session);
+    free(ctx);
+    return NULL;
+  }
+
+  session->session_ctx = (void *)ctx;
+
+  return session;
+}
+
+
+
+//==============================================================================
+// Implement internal functions.
+//
+
+//------------------------------------------------------------------------------
+//
+jcon_socket_t *jcon_socketTCP_clone(int fd, struct sockaddr_in socket_address, jlog_t *logger)
+{
+  if(fd <= 0)
+  {
+    ERROR(NULL, "Invalid file descriptor [%d].", fd);
+    return NULL;
+  }
+
+  jcon_socket_t *session = (jcon_socket_t *)malloc(sizeof(jcon_socket_t));
+  if(session == NULL)
+  {
+    ERROR(NULL, "malloc() failed.");
+    return NULL;
+  }
+
+  session->function_connect = NULL; /* Cloned sessions cannot reconnect. */
+  session->function_bind = NULL; /* Cloned sessions cannot bind. */
+  session->function_close = NULL;
+  session->function_accept = NULL; /* Cloned sessions cannot bind and therefore not accept. */
+  session->session_free_handler = &jcon_socketTCP_free;
+
+  session->file_descriptor = fd;
+  session->logger = logger;
+  session->connection_type = JCON_SOCKET_CONNECTIONTYPE_CLIENT;
+
+  jcon_socketTCP_ctx_t *ctx = (jcon_socketTCP_ctx_t *)malloc(sizeof(jcon_socketTCP_ctx_t));
+  if(ctx == NULL)
+  {
+    ERROR(NULL, "malloc() failed. Destroying session.");
+    free(session);
+    return NULL;
+  }
+
+  ctx->socket_address = socket_address;
+  session->referenceString = jcon_socketTCP_createReferenceString(socket_address);
+  if(session->referenceString == NULL)
+  {
+    ERROR(NULL, "<TCP> json_client_tcp_createReferenceString() failed. Destroying context and session.");
+    free(session);
+    free(ctx);
+    return NULL;
+  }
+
+  session->session_ctx = ctx;
+
+  return session;
+}
+
+//------------------------------------------------------------------------------
+//
+void jcon_socketTCP_free(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return;
+  }
+
+  if(session->session_ctx)
+  {
+    free(session->session_ctx);
+  }
+}
+
+//------------------------------------------------------------------------------
+//
+int jcon_socketTCP_connect(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return false;
+  }
+
+  if(jcon_socket_isConnected(session))
+  {
+    DEBUG(session, "Session is already connected.");
+    return true;
+  }
+
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if(fd < 0)
+  {
+    ERROR(session, "socket() failed [%d : %s].", errno, strerror(errno));
+    return false;
+  }
+
+  struct sockaddr_in addr = ((jcon_socketTCP_ctx_t *)session->session_ctx)->socket_address;
+
+  if(connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+  {
+    ERROR(session, "connect() failed [%d : %s]. Closing socket.", errno, strerror(errno));
+    if(close(fd) < 0)
+    {
+      ERROR(session, "close() failed [%d : %s].", errno, strerror(errno));
+    }
+    return false;
+  }
+
+  session->file_descriptor = fd;
+  return true;
+}
+
+
+//------------------------------------------------------------------------------
+//
+int jcon_socketTCP_bind(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return false;
+  }
+
+  if(jcon_socket_isConnected(session))
+  {
+    DEBUG(session, "Session is already connected.");
+    return true;
+  }
+
+  int fd = socket(AF_INET, SOCK_STREAM, 0);
+  if(fd < 0)
+  {
+    ERROR(session, "socket() failed [%d : %s].", errno, strerror(errno));
+    return false;
+  }
+
+  struct sockaddr_in addr = ((jcon_socketTCP_ctx_t *)session->session_ctx)->socket_address;
+
+  if(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+  {
+    ERROR(session, "bind() failed [%d : %s]. Closing socket.", errno, strerror(errno));
+    if(close(fd) < 0)
+    {
+      ERROR(session, "close() failed [%d : %s].", errno, strerror(errno));
+    }
+    return false;
+  }
+
+  if(listen(fd, 5) < 0)
+  {
+    ERROR(session, "listen() failed [%d : %s]. Closing socket.", errno, strerror(errno));
+    if(close(fd) < 0)
+    {
+      ERROR(session, "close() failed [%d : %s].", errno, strerror(errno));
+    }
+    return false;
+  }
+
+  session->file_descriptor = fd;
+  return true;
+}
+
+
+//------------------------------------------------------------------------------
+//
+jcon_socket_t *jcon_socketTCP_accept(jcon_socket_t *session)
+{
+  if(session == NULL)
+  {
+    ERROR(NULL, "Session is NULL.");
+    return NULL;
+  }
+
+  int new_fd;
+  struct sockaddr_in new_addr;
+  socklen_t addrlen = sizeof(struct sockaddr_in);
+
+  new_fd = accept(session->file_descriptor, (struct sockaddr *)&new_addr, &addrlen);
+  if(new_fd < 0)
+  {
+    ERROR(session, "accept() failed [%d : %s].", errno, strerror(errno));
+    return NULL;
+  }
+
+  jcon_socket_t *new_con = jcon_socketTCP_clone(new_fd, new_addr, session->logger);
+  if(new_con == NULL)
+  {
+    ERROR(session, "jcon_socket_clone() failed with new connection [TCP:%s:%u].", jcon_socketTCP_getIP(new_addr), jcon_socketTCP_getPort(new_addr));
+    close(new_fd);
+    return NULL;
+  }
+
+  return new_con;
+}
+
+//------------------------------------------------------------------------------
+//
+char *jcon_socketTCP_getIP(struct sockaddr_in socket_address)
+{
+  char *ip = inet_ntoa(socket_address.sin_addr);
+  if(ip == NULL)
+  {
+    ERROR(NULL, "inet_ntoa() failed.");
+    return NULL;
+  }
+
+  return ip;
+}
+
+//------------------------------------------------------------------------------
+//
+uint16_t jcon_socketTCP_getPort(struct sockaddr_in socket_address)
+{
+  return ntohs(socket_address.sin_port);
+}
+
+//------------------------------------------------------------------------------
+//
+char *jcon_socketTCP_createReferenceString(struct sockaddr_in socket_address)
+{
+  char buf[128] = { 0 };
+  char *ip;
+  uint16_t port;
+  
+  ip = jcon_socketTCP_getIP(socket_address);
+  if(ip == NULL)
+  {
+    ERROR(NULL, "jcon_socketTCP_getIP() failed.");
+    return NULL;
+  }
+
+  port = jcon_socketTCP_getPort(socket_address);
+  if(port == 0)
+  {
+    ERROR(NULL, "jcon_socketTCP_getPort() failed.");
+    return NULL;
+  }
+
+  if(sprintf(buf, "TCP:%s:%u", ip, port) < 0)
+  {
+    ERROR(NULL, "sprintf() failed.");
+    return NULL;
+  }
+
+  size_t size_refString = sizeof(char) * (strlen(buf) + 1);
+  char *ret = (char *)malloc(size_refString);
+  if(ret == NULL)
+  {
+    ERROR(NULL, "<TCP:%s:%u> malloc() failed.", ip, port);
+    return NULL;
+  }
+
+  /* Changed implementation from using strcpy, to using memcpy;
+     to calm down devskim checks. */
+  memset(ret, 0, size_refString);
+  memcpy(ret, buf, size_refString);
+
+  return ret;
+}
+
+//------------------------------------------------------------------------------
+//
+void jcon_socketTCP_log(jcon_socket_t *session, int log_type, const char *file, const char *function, int line, const char *fmt, ...)
+{
+  va_list args;
+  char buf[2048];
+
+  va_start(args, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, args);
+  va_end(args);
+
+  if(session)
+  {
+    if(session->logger)
+    {
+      jlog_log_message_m(session->logger, log_type, file, function, line, "<%s> %s", jcon_socket_getReferenceString(session), buf);
+    }
+    else
+    {
+      jlog_global_log_message_m(log_type, file, function, line, "<%s> %s", jcon_socket_getReferenceString(session), buf);
+    }
+  }
+  else
+  {
+    jlog_global_log_message_m(log_type, file, function, line, buf);
+  }
+}

--- a/src/jcon/jcon_socketUnix.c
+++ b/src/jcon/jcon_socketUnix.c
@@ -182,7 +182,7 @@ static void jcon_socketUnix_log(jcon_socket_t *session, int log_type, const char
 
 //------------------------------------------------------------------------------
 //
-jcon_socket_t *jcon_socketUnix_simpleInit(const char *filepath, jlog_t *logger)
+jcon_socket_t *jcon_socketUnix_simple_init(const char *filepath, jlog_t *logger)
 {
   jcon_socket_t *session = (jcon_socket_t *)malloc(sizeof(jcon_socket_t));
   if(session == NULL)

--- a/src/jcon/jcon_socketUnix.c
+++ b/src/jcon/jcon_socketUnix.c
@@ -381,6 +381,12 @@ int jcon_socketUnix_bind(jcon_socket_t *session)
 
   struct sockaddr_un addr = ((jcon_socketUnix_ctx_t *)session->session_ctx)->socket_address;
 
+  if(unlink(addr.sun_path) < 0)
+  {
+    ERROR(session, "unlink() failed [%d : %s].", errno, strerror(errno));
+    return false;
+  }
+
   if(bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0)
   {
     ERROR(session, "bind() failed [%d : %s]. Closing socket.", errno, strerror(errno));


### PR DESCRIPTION
Seperated _jcon\_tcp_ and _jcon\_unix_ to use a unified _jcon\_socket_ interface.

According to Issue #53.