### PR TITLE
[ JCONFIG ] Implemented prefix iteration.

### DIFF
--- a/exec/jayc-conf.c
+++ b/exec/jayc-conf.c
@@ -177,10 +177,15 @@ static int jaycConf_saveConfig(const char *file, int format);
 /**
  * @brief Prints all config data.
  * 
+ * @param         If hierarchical data, prefix
+ *                can be used to only search for
+ *                keys, that start with prefix.
+ *                If @c NULL , dump all keys.
+ * 
  * @return        @c true , if successful.
  * @return        @c false , if error occured.
  */
-static int jaycConf_dumpConfig();
+static int jaycConf_dumpConfig(const char *prefix);
 
 /**
  * @brief Handles CLI input.
@@ -454,11 +459,11 @@ int jaycConf_saveConfig(const char *file, int format)
 
 //------------------------------------------------------------------------------
 //
-int jaycConf_dumpConfig()
+int jaycConf_dumpConfig(const char *prefix)
 {
   jconfig_iterator_t *itr = NULL;
 
-  while( (itr = jconfig_iterate(g_data.config_data, itr)) != NULL )
+  while( (itr = jconfig_iterate(g_data.config_data, prefix, itr)) != NULL )
   {
     printf("\"%s\" = \"%s\"\n", jconfig_itr_getKey(itr), jconfig_itr_getData(itr));
   }
@@ -576,13 +581,19 @@ int jaycConf_cliHandler(const char **args, size_t arg_size, void *ctx)
   }
   else if(strcmp(args[0], JAYCCONF_CMD_DUMP) == 0)
   {
-    if(arg_size != 1)
+    if(arg_size > 2)
     {
       INFO("Invalid number of arguments for command [%s].", args[0]);
       return 0;
     }
 
-    jaycConf_dumpConfig();
+    const char *prefix = NULL;
+    if(arg_size == 2)
+    {
+      prefix = args[1];
+    }
+
+    jaycConf_dumpConfig(prefix);
     return 0;
   }
   else if(strcmp(args[0], JAYCCONF_CMD_EXIT) == 0)

--- a/inc/jayc/jconfig.h
+++ b/inc/jayc/jconfig.h
@@ -92,14 +92,17 @@ void jconfig_clear(jconfig_t *table);
 /**
  * @brief Iterates through all available datapoints.
  * 
- * @param table Config table to iterate.
- * @param itr   Iterator reference.
- *              If @c NULL , starts over.
+ * @param table   Config table to iterate.
+ * @param prefix  Only search for keys that start with prefix.
+ *                (Used for hierachrcal keys)
+ *                Ignored if @c NULL or @c "" .
+ * @param itr     Iterator reference.
+ *                If @c NULL , starts over.
  * 
- * @return      Next available element.
- * @return      @c NULL , if no more data.
+ * @return        Next available element.
+ * @return        @c NULL , if no more data.
  */
-jconfig_iterator_t *jconfig_iterate(jconfig_t *table, jconfig_iterator_t *itr);
+jconfig_iterator_t *jconfig_iterate(jconfig_t *table, const char *prefix, jconfig_iterator_t *itr);
 
 /**
  * @brief Returns key at datapoint referenced by iterator.

--- a/src/jconfig/jconfig.c
+++ b/src/jconfig/jconfig.c
@@ -180,14 +180,31 @@ void jconfig_clear(jconfig_t *table)
 
 //------------------------------------------------------------------------------
 //
-jconfig_iterator_t *jconfig_iterate(jconfig_t *table, jconfig_iterator_t *itr)
+jconfig_iterator_t *jconfig_iterate(jconfig_t *table, const char *prefix, jconfig_iterator_t *itr)
 {
   if(table == NULL)
   {
     return NULL;
   }
 
-  return (jconfig_iterator_t *)jutil_map_iterate(table->map, (jutil_map_data_t *)itr);
+  jutil_map_data_t *search = jutil_map_iterate(table->map, (jutil_map_data_t *)itr);
+
+  if(prefix == NULL || strlen(prefix) == 0)
+  {
+    return search;
+  }
+
+  while(search != NULL)
+  {
+    if(strncmp(search->index, prefix, strlen(prefix)) == 0)
+    {
+      return (jconfig_iterator_t *)search;
+    }
+
+    search = jutil_map_iterate(table->map, search);
+  }
+
+  return NULL;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
_jconfig_ can now iterate using a prefix.
This way hierarchical data can be scanned efficiently.

Already implemented in _jayc-conf_.

(Issue #61)